### PR TITLE
Bumping up versions for openKE requirements 

### DIFF
--- a/seed_embeddings/OpenKE/requirements.txt
+++ b/seed_embeddings/OpenKE/requirements.txt
@@ -21,7 +21,7 @@ cffi=1.14.5=py37h261ae71_0
 cfgv=3.2.0=py_0
 chardet=3.0.4=py37h06a4308_1003
 click=7.1.2=pyhd3eb1b0_0
-cryptography=3.2.1=py37hc72a4ac_0
+cryptography=3.3.2=py37h3c74f83_0
 distlib=0.3.1=pyh9f0ad1d_0
 editdistance=0.5.3=py37h3340039_2
 filelock=3.0.12=pyh9f0ad1d_0
@@ -58,7 +58,7 @@ nodeenv=1.5.0=pyh9f0ad1d_0
 numpy=1.19.1=py37hbc911f0_0
 numpy-base=1.19.1=py37hfa32c7d_0
 oauthlib=3.1.0=py_0
-openssl=1.1.1h=h516909a_0
+openssl=1.1.1k=h27cfd23_0
 opt_einsum=3.1.0=py_0
 pip=20.2.3=py37_0
 pre-commit=2.9.3=py37h89c1867_0
@@ -71,7 +71,7 @@ pyopenssl=20.0.1=pyhd3eb1b0_1
 pysocks=1.7.1=py37_1
 python=3.7.9=h7579374_0
 python_abi=3.7=1_cp37m
-pyyaml=5.3.1=py37hb5d75c8_1
+pyyaml=5.4.1=py37h27cfd23_1
 readline=8.0=h7b6447c_0
 requests=2.25.1=pyhd3eb1b0_0
 requests-oauthlib=1.3.0=py_0
@@ -90,7 +90,7 @@ tk=8.6.10=hbc83047_0
 toml=0.10.2=pyhd8ed1ab_0
 typing-extensions=3.7.4.3=hd3eb1b0_0
 typing_extensions=3.7.4.3=pyh06a4308_0
-urllib3=1.26.3=pyhd3eb1b0_0
+urllib3=1.26.5=pyhd8ed1ab_0
 virtualenv=20.4.2=py37h89c1867_0
 werkzeug=1.0.1=py_0
 wheel=0.35.1=py_0


### PR DESCRIPTION
pyyaml (5.3 ==> 5.4.1)
urllib3 (1.26.3 ==> 1.26.5)
cryptography (3.2.1 ==> 3.3.2)