### PR TITLE
Reduce logging verbosity.

### DIFF
--- a/src/FlowAware.cpp
+++ b/src/FlowAware.cpp
@@ -92,7 +92,7 @@ void IR2Vec_FA::collectWriteDefsMap(Module &M) {
 Vector IR2Vec_FA::getValue(std::string key) {
   Vector vec;
   if (opcMap.find(key) == opcMap.end()) {
-    errs() << "cannot find key in map : " << key << "\n";
+    IR2VEC_DEBUG(errs() << "cannot find key in map : " << key << "\n");
     dataMissCounter++;
   } else
     vec = opcMap[key];

--- a/src/Symbolic.cpp
+++ b/src/Symbolic.cpp
@@ -26,7 +26,7 @@ using abi::__cxa_demangle;
 Vector IR2Vec_Symbolic::getValue(std::string key) {
   Vector vec;
   if (opcMap.find(key) == opcMap.end())
-    errs() << "cannot find key in map : " << key << "\n";
+    IR2VEC_DEBUG(errs() << "cannot find key in map : " << key << "\n");
   else
     vec = opcMap[key];
   return vec;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<Module> IR2Vec::getLLVMIR() {
 }
 
 void IR2Vec::collectDataFromVocab(std::map<std::string, Vector> &opcMap) {
-  errs() << "Reading from " + vocab + "\n";
+  IR2VEC_DEBUG(errs() << "Reading from " + vocab + "\n");
   std::ifstream i(vocab);
   std::string delimiter = ":";
   for (std::string line; getline(i, line);) {


### PR DESCRIPTION
This is obviously up to you folks, but IMO these logging messages indicate normal program behavior so don't need to be printed to stderr by default.