### PR TITLE
add top-level CMakeLists.txt to `llvm16` branch 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         cmake ../eigen-3.3.7
         make -j4 && cd ..
     - name: cmake
-      run: cd build && cmake -DEigen3_DIR=./eigen-build ../src
+      run: cd build && cmake -DEigen3_DIR=./eigen-build ..
     - name: make
       run: cd build && make -j8
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         cmake ../eigen-3.3.7
         make -j4 && cd ..
     - name: cmake
-      run: cd build && cmake -DEigen3_DIR=./eigen-build ../src
+      run: cd build && cmake -DEigen3_DIR=./eigen-build ..
     - name: make
       run: cd build && make -j8
     - name: Run-tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.13)
+project(ir2vec VERSION 2.1.2)
+
+set(IR2VEC_LIB "IR2Vec")
+set(IR2VEC_LIB_STATIC "IR2Vec_Static")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+find_package (Eigen3 3.3.7 REQUIRED NO_MODULE)
+message(STATUS "Found Eigen3 in: ${Eigen3_DIR}")
+
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
+
+# LLVM is normally built without RTTI. Be consistent with that.
+if(NOT LLVM_ENABLE_RTTI)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+endif()
+
+add_subdirectory(src)

--- a/Manylinux2014_Compliant_Source/pkg/build.sh
+++ b/Manylinux2014_Compliant_Source/pkg/build.sh
@@ -15,11 +15,11 @@ cd eigen-build
 cmake ../eigen-3.3.7 && make && make install
 
 cd ..
-cmake -DCMAKE_BUILD_TYPE=Release ../src && make -j"$(nproc)" && make install
+cmake -DCMAKE_BUILD_TYPE=Release .. && make -j"$(nproc)" && make install
 
 cd ..
 cp src/include/utils.h Manylinux2014_Compliant_Source/pkg/ir2vec/
-cp build/version.h Manylinux2014_Compliant_Source/pkg/ir2vec/
+cp build/src/version.h Manylinux2014_Compliant_Source/pkg/ir2vec/
 cp vocabulary/seedEmbeddingVocab.txt Manylinux2014_Compliant_Source/pkg/ir2vec/
 
 bash Manylinux2014_Compliant_Source/pkg/regen-oracle.sh

--- a/Manylinux2014_Compliant_Source/pkg/setup.py
+++ b/Manylinux2014_Compliant_Source/pkg/setup.py
@@ -18,7 +18,7 @@ LLVM_LIBS = []
 VERSION = ""
 DESCRIPTION = ""
 
-with (pl.Path(__file__).resolve().parents[2] / "src" / "CMakeLists.txt").open() as f:
+with (pl.Path(__file__).resolve().parents[2] / "CMakeLists.txt").open() as f:
     for line in f:
         if not VERSION:
             vmatch = version_regex.match(line)  # Not using walrus because Python3.6

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you're a C++ developer and require low-level control, optimization, or integr
     2. `mkdir eigen-build && cd eigen-build`
     3. `cmake ../eigen-3.3.7 && make`
     4. `cd ../`
-3. `cmake -DLT_LLVM_INSTALL_DIR=<path_to_LLVM_build_dir> -DEigen3_DIR=<path_to_eigen_build_dir> [-DCMAKE_INSTALL_PREFIX=<install_dir>] ../src`
+3. `cmake -DLT_LLVM_INSTALL_DIR=<path_to_LLVM_build_dir> -DEigen3_DIR=<path_to_eigen_build_dir> [-DCMAKE_INSTALL_PREFIX=<install_dir>] ..`
 4. `make [&& make install]`
 
 This process would generate `ir2vec` binary under `build/bin` directory, `libIR2Vec.a` and `libIR2Vec.so` under `build/lib` directory.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,35 +1,6 @@
-cmake_minimum_required(VERSION 3.13)
-project(ir2vec VERSION 2.1.1)
-
-set(IR2VEC_LIB "IR2Vec")
-set(IR2VEC_LIB_STATIC "IR2Vec_Static")
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
-
-
-set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
-list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
-
-find_package(LLVM 16.0.0 REQUIRED CONFIG)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
-find_package (Eigen3 3.3.7 REQUIRED NO_MODULE)
-message(STATUS "Found Eigen3 in: ${Eigen3_DIR}")
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
-include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
-
 configure_file (./include/version.h.cmake version.h @ONLY)
 include_directories(./include ${CMAKE_CURRENT_BINARY_DIR})
 
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-
-# LLVM is normally built without RTTI. Be consistent with that.
-if(NOT LLVM_ENABLE_RTTI)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
-endif()
 
 set(commonsrc FlowAware.cpp Symbolic.cpp utils.cpp)
 set(libsrc libIR2Vec.cpp ${commonsrc})
@@ -37,50 +8,85 @@ set(binsrc CollectIR.cpp IR2Vec.cpp)
 
 file(GLOB RESOURCE_FILES ../vocabulary/seedEmbeddingVocab.txt)
 
-# llvm_map_components_to_libnames(llvm_libs all)
-llvm_map_components_to_libnames(llvm_libs support core irreader analysis TransformUtils)
+option(LLVM_IR2VEC, "where to enable IR2Vec as a subproject for LLVM" OFF)
 
-add_executable(${PROJECT_NAME} ${binsrc})
-target_link_libraries (${PROJECT_NAME} ${llvm_libs} objlib)
-target_include_directories(${PROJECT_NAME} PRIVATE .)
 
-add_library(objlib OBJECT ${libsrc})
-set_property(TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
-target_link_libraries (objlib Eigen3::Eigen)
+if(NOT LLVM_IR2VEC)
 
-add_library(${IR2VEC_LIB} SHARED $<TARGET_OBJECTS:objlib>)
-add_library(${IR2VEC_LIB_STATIC} STATIC $<TARGET_OBJECTS:objlib>)
-set_target_properties(${IR2VEC_LIB} ${IR2VEC_LIB_STATIC} PROPERTIES
-    VERSION ${PROJECT_VERSION}
-    SOVERSION 1
-    PUBLIC_HEADER "./include/IR2Vec.h"
-    RESOURCE ${RESOURCE_FILES}
-    OUTPUT_NAME ${IR2VEC_LIB}
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-    )
+  set(LT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
+  list(APPEND CMAKE_PREFIX_PATH "${LT_LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 
-install(TARGETS ${IR2VEC_LIB} ${IR2VEC_LIB_STATIC}
-    LIBRARY DESTINATION lib
-    PUBLIC_HEADER DESTINATION include
-    RESOURCE DESTINATION ./)
+  find_package(LLVM 16.0.0 REQUIRED CONFIG)
+  message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
-add_subdirectory(test-suite)
+  include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 
-add_custom_target(verify-symbolic
- COMMAND bash ./sanity_check.sh SYM llvm16
- COMMENT "Generating Symbolic IR2Vec vectors and comparing with oracle..."
- WORKING_DIRECTORY ./test-suite
- DEPENDS ${PROJECT_NAME}
- VERBATIM
- )
+  include_directories(./include ${CMAKE_CURRENT_BINARY_DIR})
 
-add_custom_target(verify-flowaware
- COMMAND bash sanity_check.sh FA llvm16
- COMMENT "Generating Flow-Aware IR2Vec vectors and comparing with oracle..."
- WORKING_DIRECTORY ./test-suite
- DEPENDS ${PROJECT_NAME}
- VERBATIM
- )
 
-add_custom_target(verify-all DEPENDS verify-symbolic verify-flowaware)
+  llvm_map_components_to_libnames(llvm_libs support core irreader analysis TransformUtils)
+
+  add_executable(${PROJECT_NAME} ${binsrc})
+  target_link_libraries (${PROJECT_NAME} ${llvm_libs} objlib)
+  target_include_directories(${PROJECT_NAME} PRIVATE .)
+
+  add_library(objlib OBJECT ${libsrc})
+  set_property(TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
+  target_link_libraries (objlib Eigen3::Eigen)
+
+  add_library(${IR2VEC_LIB} SHARED $<TARGET_OBJECTS:objlib>)
+  add_library(${IR2VEC_LIB_STATIC} STATIC $<TARGET_OBJECTS:objlib>)
+  set_target_properties(${IR2VEC_LIB} ${IR2VEC_LIB_STATIC} PROPERTIES
+      VERSION ${PROJECT_VERSION}
+      SOVERSION 1
+      PUBLIC_HEADER "./include/IR2Vec.h"
+      RESOURCE ${RESOURCE_FILES}
+      OUTPUT_NAME ${IR2VEC_LIB}
+      LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+      ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+      )
+
+  install(TARGETS ${IR2VEC_LIB} ${IR2VEC_LIB_STATIC}
+      LIBRARY DESTINATION lib
+      PUBLIC_HEADER DESTINATION include
+      RESOURCE DESTINATION ./)
+
+  add_subdirectory(test-suite)
+
+  add_custom_target(verify-symbolic
+  COMMAND bash ./sanity_check.sh SYM llvm16
+  COMMENT "Generating Symbolic IR2Vec vectors and comparing with oracle..."
+  WORKING_DIRECTORY ./test-suite
+  DEPENDS ${PROJECT_NAME}
+  VERBATIM
+  )
+
+  add_custom_target(verify-flowaware
+  COMMAND bash sanity_check.sh FA llvm16
+  COMMENT "Generating Flow-Aware IR2Vec vectors and comparing with oracle..."
+  WORKING_DIRECTORY ./test-suite
+  DEPENDS ${PROJECT_NAME}
+  VERBATIM
+  )
+
+  add_custom_target(verify-all DEPENDS verify-symbolic verify-flowaware)
+  
+else()
+
+  file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/include/IR2Vec.h DESTINATION ${LLVM_MAIN_INCLUDE_DIR}/llvm )
+  
+  set(LLVM_OPTIONAL_SOURCES ${binsrc})
+  
+  add_llvm_library(LLVMIR2Vec
+    ${libsrc}
+  
+    DEPENDS
+    intrinsics_gen
+  )
+  
+  target_link_libraries(LLVMIR2Vec PRIVATE Eigen3::Eigen)
+  target_include_directories(LLVMIR2Vec PRIVATE ${LLVM_MAIN_INCLUDE_DIR})
+  target_include_directories(LLVMIR2Vec PRIVATE .)
+
+endif()

--- a/src/test-suite/sanity_check.sh.cmake
+++ b/src/test-suite/sanity_check.sh.cmake
@@ -26,7 +26,7 @@ fi
 
 SEED_VERSION=$2
 VOCAB_PATH="./vocabulary/seedEmbeddingVocab.txt"
-IR2VEC_PATH="../bin/ir2vec"
+IR2VEC_PATH="../../bin/ir2vec"
 
 functions=("main" "buildMatchingMachine" "search" "BellamFord" "BFS" "isBCUtil" "insertionSort" "binomialCoeff" "find" "countParenth" "boruvkaMST" "maxStackHeight" "badCharHeuristic" "bpm"
     "count" "getMaxUtil" "buildSuffixArray" "countOnes" "countStrings" "countRec" "countWays" "AP" "cutRod" "isCyclic" "isDivisible" "DFS" "editDist" "eggDrop" "isSC" "isConnected" "printClosest"


### PR DESCRIPTION
Hi, 
This PR implements #54 for the `llvm16` branch. This is based on the changes merged in #94 for the main branch. 

I think the following checklist could be helpful to follow when updating the other LLVM release branches: 
- [x] add top level `CMakeLists.txt`
- [x] update `src/CMakeLists.txt`
- [x] update IR2Vec relative path in `src/test-suite/sanity_check.sh.cmake`
- [x] run `make verify-all` to ensure everything is working correctly
- [x] update python package paths
- [x] update workflows paths
- [x] update `README.md` build from source section

Please let me know if any additional changes are needed.

Thank you.